### PR TITLE
POC: Reset socket when device is powered on

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -194,6 +194,10 @@ Bleno.prototype.onAdvertisingStop = function() {
   this.emit('advertisingStop');
 };
 
+Bleno.prototype.setMaxMtu = function(mtu) {
+  return this._bindings.setMaxMtu(mtu);
+};
+
 Bleno.prototype.setDeviceName = function(name) {
   return this._bindings.setDeviceName(name);
 };

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -194,6 +194,10 @@ Bleno.prototype.onAdvertisingStop = function() {
   this.emit('advertisingStop');
 };
 
+Bleno.prototype.setDeviceName = function(name) {
+  return this._bindings.setDeviceName(name);
+};
+
 Bleno.prototype.setServices = function(services, callback) {
   if (callback) {
     this.once('servicesSet', callback);

--- a/lib/hci-socket/acl-stream.js
+++ b/lib/hci-socket/acl-stream.js
@@ -18,7 +18,7 @@ util.inherits(AclStream, events.EventEmitter);
 
 
 AclStream.prototype.write = function(cid, data) {
-  this._hci.writeAclDataPkt(this._handle, cid, data);
+  this._hci.queueAclDataPkt(this._handle, cid, data);
 };
 
 AclStream.prototype.push = function(cid, data) {

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -9,11 +9,6 @@ var Hci = require('./hci');
 var Gap = require('./gap');
 var Gatt = require('./gatt');
 
-var MaxMtus = {
-  '2' : 23, // Intel Corporation
-  '93': 23 // Realtek Semiconductor Corporation
-};
-
 var BlenoBindings = function() {
   this._state = null;
 
@@ -134,10 +129,7 @@ BlenoBindings.prototype.onAddressChange = function(address) {
 };
 
 BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
-  var manuMaxMtu = MaxMtus[manufacturer.toString()];
-  if (manuMaxMtu) {
-    this.setMaxMtu(manuMaxMtu);
-  }
+
 };
 
 BlenoBindings.prototype.onAdvertisingStart = function(error) {

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -49,6 +49,11 @@ BlenoBindings.prototype.stopAdvertising = function() {
   this._gap.stopAdvertising();
 };
 
+
+BlenoBindings.prototype.setDeviceName = function(mtu) {
+  this._gatt.setDeviceName(mtu);
+};
+
 BlenoBindings.prototype.setServices = function(services) {
   this._gatt.setServices(services);
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -9,6 +9,11 @@ var Hci = require('./hci');
 var Gap = require('./gap');
 var Gatt = require('./gatt');
 
+var MaxMtus = {
+  '2' : 23, // Intel Corporation
+  '93': 23 // Realtek Semiconductor Corporation
+};
+
 var BlenoBindings = function() {
   this._state = null;
 
@@ -49,6 +54,9 @@ BlenoBindings.prototype.stopAdvertising = function() {
   this._gap.stopAdvertising();
 };
 
+BlenoBindings.prototype.setMaxMtu = function(mtu) {
+  this._gatt.setMaxMtu(mtu);
+};
 
 BlenoBindings.prototype.setDeviceName = function(mtu) {
   this._gatt.setDeviceName(mtu);
@@ -126,12 +134,9 @@ BlenoBindings.prototype.onAddressChange = function(address) {
 };
 
 BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
-  if (manufacturer === 2) {
-    // Intel Corporation
-    this._gatt.maxMtu = 23;
-  } else if (manufacturer === 93) {
-    // Realtek Semiconductor Corporation
-    this._gatt.maxMtu = 23;
+  var manuMaxMtu = MaxMtus[manufacturer.toString()];
+  if (manuMaxMtu) {
+    this.setMaxMtu(manuMaxMtu);
   }
 };
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -64,8 +64,8 @@ var ATT_ECODE_INSUFF_RESOURCES      = 0x11;
 var ATT_CID = 0x0004;
 
 var Gatt = function() {
-  this.maxMtu = 256;
   this._mtu = 23;
+  this._maxMtu = process.env.BLENO_MAX_MTU || 256;
   this._preparedWriteRequest = null;
   this._deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
 
@@ -76,6 +76,10 @@ var Gatt = function() {
 };
 
 util.inherits(Gatt, events.EventEmitter);
+
+Gatt.prototype.setMaxMtu = function(mtu) {
+  this._maxMtu = mtu;
+};
 
 Gatt.prototype.setDeviceName = function(name) {
   this._deviceName = name;
@@ -380,13 +384,14 @@ Gatt.prototype.handleMtuRequest = function(request) {
 
   if (mtu < 23) {
     mtu = 23;
-  } else if (mtu > this.maxMtu) {
-    mtu = this.maxMtu;
+  } else if (mtu > this._maxMtu) {
+    mtu = this._maxMtu;
   }
 
-  this._mtu = mtu;
-
-  this.emit('mtuChange', this._mtu);
+  if (this._mtu !== mtu) {
+    this._mtu = mtu;
+    this.emit('mtuChange', this._mtu);
+  }
 
   var response = new Buffer(3);
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -67,6 +67,7 @@ var Gatt = function() {
   this.maxMtu = 256;
   this._mtu = 23;
   this._preparedWriteRequest = null;
+  this._deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
 
   this.setServices([]);
 
@@ -76,8 +77,12 @@ var Gatt = function() {
 
 util.inherits(Gatt, events.EventEmitter);
 
+Gatt.prototype.setDeviceName = function(name) {
+  this._deviceName = name;
+};
+
 Gatt.prototype.setServices = function(services) {
-  var deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
+  var deviceName = this._deviceName;
 
   // base services and characteristics
   var allServices = [

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -17,6 +17,7 @@ var EVT_DISCONN_COMPLETE = 0x05;
 var EVT_ENCRYPT_CHANGE = 0x08;
 var EVT_CMD_COMPLETE = 0x0e;
 var EVT_CMD_STATUS = 0x0f;
+var EVT_NUMBER_OF_COMPLETED_PACKETS = 0x13;
 var EVT_LE_META_EVENT = 0x3e;
 
 var EVT_LE_CONN_COMPLETE = 0x01;
@@ -81,8 +82,12 @@ var Hci = function() {
   // le-u min payload size + l2cap header size
   // see Bluetooth spec 4.2 [Vol 3, Part A, Chapter 4]
   this._acl_mtu = 23 + 4;
-
+  this._acl_queue = 1;
+  
+  this._cmdTxCreds = 1;
+  this._handleInFlight = {};
   this._handleBuffers = {};
+  this._aclOutQueue = [];
 
   this.on('stateChange', this.onStateChange.bind(this));
 };
@@ -142,7 +147,7 @@ Hci.prototype.initDev = function() {
 Hci.prototype.setSocketFilter = function() {
   var filter = new Buffer(14);
   var typeMask = (1 << HCI_EVENT_PKT)| (1 << HCI_ACLDATA_PKT);
-  var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
+  var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS) | ( 1 << EVT_NUMBER_OF_COMPLETED_PACKETS);
   var eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
   var opcode = 0;
 
@@ -411,7 +416,7 @@ Hci.prototype.readBufferSize = function() {
   this._socket.write(cmd);
 };
 
-Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
+Hci.prototype.queueAclDataPkt = function(handle, cid, data) {
   var hf = handle | ACL_START_NO_FLUSH << 12;
   // l2cap pdu may be fragmented on hci level
   var l2capPdu = new Buffer(4 + data.length);
@@ -432,12 +437,40 @@ Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
     pkt.writeUInt16LE(frag.length, 3); // hci pdu length
 
     frag.copy(pkt, 5);
-
-    debug('write acl data pkt frag ' + fragId + ' - writing: ' + pkt.toString('hex'));
-    this._socket.write(pkt);
-    fragId++;
+    
+    this._aclOutQueue.push({
+      handle: handle,
+      pkt: pkt,
+      fragId: fragId++
+    });
   }
+  
+  this.pushAclOutQueue();
 };
+
+Hci.prototype.pushAclOutQueue = function() {
+  var inFlight = 0;
+  for (var handle in this._handleInFlight) {
+    inFlight += this._handleInFlight[handle];
+  }
+  while (inFlight < this._acl_queue && this._aclOutQueue.length) {
+    inFlight++;
+    this.writeOneAclDataPkt();
+  }
+  
+  if (inFlight >= this._acl_queue) {
+    debug("acl out queue congested");
+    debug("\tin flight = " + inFlight);
+    debug("\tqueued = " + this._aclOutQueue.length);
+  }
+}
+
+Hci.prototype.writeOneAclDataPkt = function() {
+  var pkt = this._aclOutQueue.shift();
+  debug('write acl data pkt frag ' + pkt.fragId + ' - writing: ' + pkt.pkt.toString('hex'));
+  this._socket.write(pkt.pkt);
+  this._handleInFlight[pkt.handle]++;
+}
 
 Hci.prototype.onSocketData = function(data) {
   debug('onSocketData: ' + data.toString('hex'));
@@ -469,10 +502,12 @@ Hci.prototype.onSocketData = function(data) {
 
       this.emit('encryptChange', handle, encrypt);
     } else if (subEventType === EVT_CMD_COMPLETE) {
+      var ncmd = data.readUInt8(3);
       var cmd = data.readUInt16LE(4);
       var status = data.readUInt8(6);
       var result = data.slice(7);
 
+      debug('\t\tncmd = ' + ncmd);
       debug('\t\tcmd = ' + cmd);
       debug('\t\tstatus = ' + status);
       debug('\t\tresult = ' + result.toString('hex'));
@@ -488,6 +523,21 @@ Hci.prototype.onSocketData = function(data) {
       debug('\t\tLE meta event data = ' + leMetaEventData.toString('hex'));
 
       this.processLeMetaEvent(leMetaEventType, leMetaEventStatus, leMetaEventData);
+    } else if (subEventType === EVT_NUMBER_OF_COMPLETED_PACKETS) {
+      var handles = data.readUInt8(3);
+      for (var i = 0; i < handles; i++) {
+	var handle = data.readUInt16LE(4 + i * 4);
+	var pkts = data.readUInt16LE(4 + 2 + i * 4);
+	if (pkts > this._handleInFlight[handle]) {
+	  this._handleInFlight[handle] = 0;
+	} else {
+	  this._handleInFlight[handle] -= pkts;
+	}
+	debug("\thandle = " + handle);
+	debug("\t\tcompleted = " + pkts);
+	debug("\t\tin flight = " + this._handleInFlight[handle]);
+      }
+      this.pushAclOutQueue();
     }
   } else if (HCI_ACLDATA_PKT === eventType) {
     var flags = data.readUInt16LE(1) >> 12;
@@ -607,10 +657,13 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
   } else if (cmd === READ_BUFFER_SIZE_CMD) {
     if (!status) {
       var acl_mtu = result.readUInt16LE(0);
+      var acl_queue = result.readUInt16LE(3);
       // sanity
-      if (acl_mtu) {
+      if (acl_mtu && acl_queue) {
 	debug('br/edr acl_mtu = ' + acl_mtu);
+	debug('br/edr acl_queue = ' + acl_queue);
 	this._acl_mtu = acl_mtu;
+	this._acl_queue = acl_queue;
       }
     }
   }
@@ -627,6 +680,7 @@ Hci.prototype.processLeReadBufferSize = function(result) {
     debug('le acl_mtu = ' + acl_mtu);
     debug('le acl_queue = ' + acl_queue);
     this._acl_mtu = acl_mtu;
+    this._acl_queue = acl_queue;
   }
 }
 
@@ -656,6 +710,8 @@ Hci.prototype.processLeConnComplete = function(status, data) {
   debug('\t\t\tlatency = ' + latency);
   debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
   debug('\t\t\tmaster clock accuracy = ' + masterClockAccuracy);
+  
+  this._handleInFlight[handle] = 0;
 
   this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
 };

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -83,7 +83,7 @@ var Hci = function() {
   // see Bluetooth spec 4.2 [Vol 3, Part A, Chapter 4]
   this._acl_mtu = 23 + 4;
   this._acl_queue = 1;
-  
+
   this._cmdTxCreds = 1;
   this._handleInFlight = {};
   this._handleBuffers = {};
@@ -131,7 +131,7 @@ Hci.prototype.pollIsDevUp = function() {
     this._isDevUp = isDevUp;
   }
 
-  setTimeout(this.pollIsDevUp.bind(this), 1000);
+  setTimeout(this.pollIsDevUp.bind(this), 1000).unref();
 };
 
 Hci.prototype.initDev = function() {
@@ -437,14 +437,14 @@ Hci.prototype.queueAclDataPkt = function(handle, cid, data) {
     pkt.writeUInt16LE(frag.length, 3); // hci pdu length
 
     frag.copy(pkt, 5);
-    
+
     this._aclOutQueue.push({
       handle: handle,
       pkt: pkt,
       fragId: fragId++
     });
   }
-  
+
   this.pushAclOutQueue();
 };
 
@@ -457,7 +457,7 @@ Hci.prototype.pushAclOutQueue = function() {
     inFlight++;
     this.writeOneAclDataPkt();
   }
-  
+
   if (inFlight >= this._acl_queue) {
     debug("acl out queue congested");
     debug("\tin flight = " + inFlight);
@@ -710,7 +710,7 @@ Hci.prototype.processLeConnComplete = function(status, data) {
   debug('\t\t\tlatency = ' + latency);
   debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
   debug('\t\t\tmaster clock accuracy = ' + masterClockAccuracy);
-  
+
   this._handleInFlight[handle] = 0;
 
   this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -122,8 +122,15 @@ Hci.prototype.pollIsDevUp = function() {
 
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
+      if (this._isDevUp === false) {
+        this._isDevUp = isDevUp
+        this._socket.stop()
+        this._socket = new BluetoothHciSocket();
+        this.init()
+      }
       this.setSocketFilter();
       this.initDev();
+      this.emit('stateChange', 'poweredOn');
     } else {
       this.emit('stateChange', 'poweredOff');
     }

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -33,6 +33,7 @@ var OCF_WRITE_LE_HOST_SUPPORTED = 0x006d;
 
 var OGF_INFO_PARAM = 0x04;
 var OCF_READ_LOCAL_VERSION = 0x0001;
+var OCF_READ_BUFFER_SIZE = 0x0005;
 var OCF_READ_BD_ADDR = 0x0009;
 
 var OGF_STATUS_PARAM = 0x05;
@@ -40,6 +41,7 @@ var OCF_READ_RSSI = 0x0005;
 
 var OGF_LE_CTL = 0x08;
 var OCF_LE_SET_EVENT_MASK = 0x0001;
+var OCF_LE_READ_BUFFER_SIZE = 0x0002;
 var OCF_LE_SET_ADVERTISING_PARAMETERS = 0x0006;
 var OCF_LE_SET_ADVERTISING_DATA = 0x0008;
 var OCF_LE_SET_SCAN_RESPONSE_DATA = 0x0009;
@@ -54,11 +56,13 @@ var READ_LE_HOST_SUPPORTED_CMD = OCF_READ_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10
 var WRITE_LE_HOST_SUPPORTED_CMD = OCF_WRITE_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
 
 var READ_LOCAL_VERSION_CMD = OCF_READ_LOCAL_VERSION | (OGF_INFO_PARAM << 10);
+var READ_BUFFER_SIZE_CMD = OCF_READ_BUFFER_SIZE | (OGF_INFO_PARAM << 10);
 var READ_BD_ADDR_CMD = OCF_READ_BD_ADDR | (OGF_INFO_PARAM << 10);
 
 var READ_RSSI_CMD = OCF_READ_RSSI | OGF_STATUS_PARAM << 10;
 
 var LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
+var LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | OGF_LE_CTL << 10;
 var LE_SET_ADVERTISING_PARAMETERS_CMD = OCF_LE_SET_ADVERTISING_PARAMETERS | OGF_LE_CTL << 10;
 var LE_SET_ADVERTISING_DATA_CMD = OCF_LE_SET_ADVERTISING_DATA | OGF_LE_CTL << 10;
 var LE_SET_SCAN_RESPONSE_DATA_CMD = OCF_LE_SET_SCAN_RESPONSE_DATA | OGF_LE_CTL << 10;
@@ -74,6 +78,9 @@ var Hci = function() {
   this._isDevUp = null;
   this._state = null;
   this._deviceId = null;
+  // le-u min payload size + l2cap header size
+  // see Bluetooth spec 4.2 [Vol 3, Part A, Chapter 4]
+  this._acl_mtu = 23 + 4;
 
   this._handleBuffers = {};
 
@@ -111,12 +118,7 @@ Hci.prototype.pollIsDevUp = function() {
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
       this.setSocketFilter();
-      this.setEventMask();
-      this.setLeEventMask();
-      this.readLocalVersion();
-      this.writeLeHostSupported();
-      this.readLeHostSupported();
-      this.readBdAddr();
+      this.initDev();
     } else {
       this.emit('stateChange', 'poweredOff');
     }
@@ -126,6 +128,16 @@ Hci.prototype.pollIsDevUp = function() {
 
   setTimeout(this.pollIsDevUp.bind(this), 1000);
 };
+
+Hci.prototype.initDev = function() {
+  this.setEventMask();
+  this.setLeEventMask();
+  this.readLocalVersion();
+  this.writeLeHostSupported();
+  this.readLeHostSupported();
+  this.readBdAddr();
+  this.leReadBufferSize();
+}
 
 Hci.prototype.setSocketFilter = function() {
   var filter = new Buffer(14);
@@ -371,20 +383,60 @@ Hci.prototype.readRssi = function(handle) {
   this._socket.write(cmd);
 };
 
-Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
-  var pkt = new Buffer(9 + data.length);
+Hci.prototype.leReadBufferSize = function() {
+  var cmd = new Buffer(4);
 
   // header
-  pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
-  pkt.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
-  pkt.writeUInt16LE(data.length + 4, 3); // data length 1
-  pkt.writeUInt16LE(data.length, 5); // data length 2
-  pkt.writeUInt16LE(cid, 7);
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_READ_BUFFER_SIZE_CMD, 1);
 
-  data.copy(pkt, 9);
+  // length
+  cmd.writeUInt8(0x0, 3);
 
-  debug('write acl data pkt - writing: ' + pkt.toString('hex'));
-  this._socket.write(pkt);
+  debug('le read buffer size - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readBufferSize = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_BUFFER_SIZE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug('read buffer size - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
+  var hf = handle | ACL_START_NO_FLUSH << 12;
+  // l2cap pdu may be fragmented on hci level
+  var l2capPdu = new Buffer(4 + data.length);
+  l2capPdu.writeUInt16LE(data.length, 0);
+  l2capPdu.writeUInt16LE(cid, 2);
+  data.copy(l2capPdu, 4);
+  var fragId = 0;
+
+  while (l2capPdu.length) {
+    var frag = l2capPdu.slice(0, this._acl_mtu);
+    l2capPdu = l2capPdu.slice(frag.length);
+    var pkt = new Buffer(5 + frag.length);
+
+    // hci header
+    pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
+    pkt.writeUInt16LE(hf, 1);
+    hf |= ACL_CONT << 12;
+    pkt.writeUInt16LE(frag.length, 3); // hci pdu length
+
+    frag.copy(pkt, 5);
+
+    debug('write acl data pkt frag ' + fragId + ' - writing: ' + pkt.toString('hex'));
+    this._socket.write(pkt);
+    fragId++;
+  }
 };
 
 Hci.prototype.onSocketData = function(data) {
@@ -494,12 +546,7 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
   var handle;
 
   if (cmd === RESET_CMD) {
-    this.setEventMask();
-    this.setLeEventMask();
-    this.readLocalVersion();
-    this.writeLeHostSupported();
-    this.readLeHostSupported();
-    this.readBdAddr();
+    this.initDev();
   } else if (cmd === READ_LE_HOST_SUPPORTED_CMD) {
     if (status === 0) {
       var le = result.readUInt8(0);
@@ -553,8 +600,35 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
 
     debug('\t\t\thandle = ' + handle);
     this.emit('leLtkNegReply', handle);
+  } else if (cmd === LE_READ_BUFFER_SIZE_CMD) {
+    if (!status) {
+      this.processLeReadBufferSize(result);
+    }
+  } else if (cmd === READ_BUFFER_SIZE_CMD) {
+    if (!status) {
+      var acl_mtu = result.readUInt16LE(0);
+      // sanity
+      if (acl_mtu) {
+	debug('br/edr acl_mtu = ' + acl_mtu);
+	this._acl_mtu = acl_mtu;
+      }
+    }
   }
 };
+
+Hci.prototype.processLeReadBufferSize = function(result) {
+  var acl_mtu = result.readUInt16LE(0);
+  var acl_queue = result.readUInt8(2);
+  if (!acl_mtu) {
+    // as per Bluetooth specs
+    debug('falling back to br/edr buffer size');
+    this.readBufferSize();
+  } else {
+    debug('le acl_mtu = ' + acl_mtu);
+    debug('le acl_queue = ' + acl_queue);
+    this._acl_mtu = acl_mtu;
+  }
+}
 
 Hci.prototype.processLeMetaEvent = function(eventType, status, data) {
   if (eventType === EVT_LE_CONN_COMPLETE) {

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -157,6 +157,10 @@ blenoBindings.on('kCBMsgId17', function(args) {
   this.emit('advertisingStop');
 });
 
+blenoBindings.setDeviceName = function (name) {
+  console.warn('bleno does not support setDeviceName() on macOS/OSX');
+};
+
 blenoBindings.setServices = function(services) {
   this.sendCBMsg(12, null); // remove all services
 

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -157,6 +157,10 @@ blenoBindings.on('kCBMsgId17', function(args) {
   this.emit('advertisingStop');
 });
 
+blenoBindings.setMaxMtu = function(mtu) {
+  console.warn('bleno does not support setMaxMtu() on macOS/OSX');
+};
+
 blenoBindings.setDeviceName = function (name) {
   console.warn('bleno does not support setDeviceName() on macOS/OSX');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubnt/bleno",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubnt/bleno",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bleno",
-  "version": "0.4.1",
+  "name": "@ubnt/bleno",
+  "version": "0.4.3",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubnt/bleno",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
On UAS when the `bleno` is started while the BT device is disabled the `bleno`
remains in a `poweredOff` state even after the device is enabled.

This PR adds a reset of the BT socket after the device is powered on. This is meant as a proof of concept. There may be some other/better way to do that.

## Testing

Disable BT and UAS service on UAS server:
```
echo '2-1.3.3' > /sys/bus/usb/drivers/usb/unbind # disable BT
cd /usr/share/uas
systemctl uas stop
```

Start the uas manually with debug logs:
```
DEBUG="hci,bleno" node uas.js
```

This should produce a `File descriptor in bad state` error:
```
bleno platform linux +0ms
bleno stateChange poweredOff +1ms
hci set advertise enable - writing: 010a200100 +473ms
hci onSocketError: File descriptor in bad state +1ms
```

While the UAS service is still running, enable the BT:
```
echo '2-1.3.3' > /sys/bus/usb/drivers/usb/bind` # enable BT
```

The `bleno` state should change to `poweredOn`:
```
bleno stateChange poweredOn +1ms
hci onSocketData: 040e0401010c00 +0ms
hci 	event type = 4 +0ms
hci 	sub event type = 14 +0ms
hci 		ncmd = 1 +1ms
hci 		cmd = 3073 +0ms
hci 		status = 0 +0ms
hci 		result =  +0ms
```
