### PR TITLE
Do not start polling timer again when the device becomes online

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -123,6 +123,7 @@ Hci.prototype.resetBuffers = function() {
 Hci.prototype.pollIsDevUp = function() {
   var isDevUp = this._socket.isDevUp();
 
+  var keepPolling = true;
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
       if (this._isDevUp === false) {
@@ -130,6 +131,7 @@ Hci.prototype.pollIsDevUp = function() {
         this._socket.stop()
         this._socket = new BluetoothHciSocket();
         this.init()
+        keepPolling = false; // init called pollIsDevUp again
       }
       this.setSocketFilter();
       this.initDev();
@@ -140,8 +142,9 @@ Hci.prototype.pollIsDevUp = function() {
 
     this._isDevUp = isDevUp;
   }
-
-  setTimeout(this.pollIsDevUp.bind(this), 1000).unref();
+  if (keepPolling) {
+    setTimeout(this.pollIsDevUp.bind(this), 1000).unref();
+  }
 };
 
 Hci.prototype.initDev = function() {


### PR DESCRIPTION
When the hci was restarted the polling was setup again but the old poling was not stopped.